### PR TITLE
fix security

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -23,7 +23,7 @@ server.register([inert, vision, hapiAuth, cookieAuth], (err) => {
   const options = {
     password: process.env.COOKIE_PASSWORD,
     cookie: 'logged-in',
-    isSecure: false,
+    isSecure: process.env.NODE_ENV !== 'DEV',
     ttl: 24 * 60 * 60 * 1000,
   };
 


### PR DESCRIPTION
we set isSecure to flase for local testing due to not using https, we needed to change this for heroku deployment so it is now fixed
relates to #19